### PR TITLE
Resolve typo: `orthographiy` -> `orthography`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 I'm Stéphan Tulkens! I'm a computational linguistics/AI person. I am currently working as a data scientist at [dataprovider.com](https://www.dataprovider.com), where I mainly work on small classifiers that operate on large volumes of web text. I live in beautiful Groningen, together with my partner and twin boy and girl. 
 
-I got my Phd at [CLiPS](https://www.uantwerpen.be/en/research-groups/clips/) at the University of Antwerpen under the watchful eyes of Walter Daelemans (Computational Linguistics) and Dominiek Sandra (Psycholinguistics). The topic of my Phd was the way people process orthographiy during reading. You can find a copy [here](https://scholar.google.com/scholar?oi=bibs&hl=en&cluster=11519863597548395702).
+I got my Phd at [CLiPS](https://www.uantwerpen.be/en/research-groups/clips/) at the University of Antwerpen under the watchful eyes of Walter Daelemans (Computational Linguistics) and Dominiek Sandra (Psycholinguistics). The topic of my Phd was the way people process orthography during reading. You can find a copy [here](https://scholar.google.com/scholar?oi=bibs&hl=en&cluster=11519863597548395702).
 Before that I studied computational linguistics (Ma), philosophy (Ba) and software engineering (Ba)
 
 My goal is always to make things as fast and small as possible. I like it when simple models work well, and I love it when simple models get close in accuracy to big models. I do not believe absolute accuracy is a metric to be chased, and I think we should always be mindful of what a model computes or learns from the data.


### PR DESCRIPTION
Hello!

This PR should speak for itself.
I assume `orthography` is what you originally intended.

You've got a well written README here and a nice GitHub profile! Always nice to see another Dutch person in the field of computational linguistics/NLP.

- Tom Aarsen